### PR TITLE
fix: make async workflow to have enough time to trigger the API

### DIFF
--- a/.github/workflows/pull-request-local-testing.yml
+++ b/.github/workflows/pull-request-local-testing.yml
@@ -20,28 +20,13 @@ jobs:
       - name: Start nginx
         run: docker compose -f test/docker-compose.yaml up -d
 
-      # - name: Test changes
-      #   uses: ./
-      #   with:
-      #     api-key: ${{ secrets.API_KEY }}
-      #     test-suite-id: cm51jnwks0001l103b5lrprjs
-      #     github-comment: true
-      #     githubToken: ${{ secrets.GITHUB_TOKEN }}
-      #     url-replacement: |-
-      #       https://nginx.com
-      #       http://localhost:8080
-
       - name: Test changes
         uses: ./
         with:
           api-key: ${{ secrets.API_KEY }}
-          async: true
           test-suite-id: cm51jnwks0001l103b5lrprjs
           github-comment: true
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           url-replacement: |-
             https://nginx.com
             http://localhost:8080
-      
-      - name: Wait 60s to see if the async test is complete
-        run: sleep 60

--- a/.github/workflows/pull-request-local-testing.yml
+++ b/.github/workflows/pull-request-local-testing.yml
@@ -20,13 +20,28 @@ jobs:
       - name: Start nginx
         run: docker compose -f test/docker-compose.yaml up -d
 
+      # - name: Test changes
+      #   uses: ./
+      #   with:
+      #     api-key: ${{ secrets.API_KEY }}
+      #     test-suite-id: cm51jnwks0001l103b5lrprjs
+      #     github-comment: true
+      #     githubToken: ${{ secrets.GITHUB_TOKEN }}
+      #     url-replacement: |-
+      #       https://nginx.com
+      #       http://localhost:8080
+
       - name: Test changes
         uses: ./
         with:
           api-key: ${{ secrets.API_KEY }}
+          async: true
           test-suite-id: cm51jnwks0001l103b5lrprjs
           github-comment: true
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           url-replacement: |-
             https://nginx.com
             http://localhost:8080
+      
+      - name: Wait 60s to see if the async test is complete
+        run: sleep 60

--- a/dist/index.js
+++ b/dist/index.js
@@ -29533,6 +29533,16 @@ async function run() {
             githubMetadata
         });
         if (runInAsyncMode) {
+            // Make sure that we give enough time for the API call to be sent to the server
+            // we expect the timeout to always resolve first.
+            await Promise.any([
+                runResultPromise,
+                new Promise(resolve => {
+                    setTimeout(() => {
+                        resolve(null);
+                    }, 5000);
+                })
+            ]);
             return;
         }
         try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,16 @@ export async function run(): Promise<void> {
     });
 
     if (runInAsyncMode) {
+      // Make sure that we give enough time for the API call to be sent to the server
+      // we expect the timeout to always resolve first.
+      await Promise.any([
+        runResultPromise,
+        new Promise(resolve => {
+          setTimeout(() => {
+            resolve(null);
+          }, 5000);
+        })
+      ]);
       return;
     }
 


### PR DESCRIPTION
Problem was that we were returning - and exiting the workflow - before the action could trigger the API. Now we wait 5s before exiting to ensure that the API was triggered.