### PR TITLE
feat: add environment-name input for v2 runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Run test suites using Stably's agent (v2) test runner.
 | api-key            | ✅           |                       | Your API key                                                                                                                                                                                                                                                                                       |
 | project-id         | ✅           |                       | Your Stably project ID                                                                                                                                                                                                                                                                             |
 | playwright-project-name |         |                       | The Playwright project name to run. Maps to the `--project` CLI flag. Optional - if not provided, all projects will run.                                                                                                                                                                          |
-| env-overrides      |              |                       | A YAML string or JSON object containing environment variable overrides. Each key is a variable name and the value is a string.                                                                                                                                                                                    |
-| github-comment     |              | true                  | When enabled, will leave a comment on either the commit or PR with relevant test results. Requires proper permissions (see [Permissions](#permissions) section below).                                                                                                                             |               |
+| environment-name   |              |                       | Name of the environment to use for this run (e.g. "Staging", "Production"). When omitted, falls back to the project's default environment.                                                                                                                                                        |
+| env-overrides      |              |                       | A YAML string or JSON object containing environment variable overrides. Each key is a variable name and the value is a string. These take precedence over environment variables.                                                                                                                   |
+| github-comment     |              | true                  | When enabled, will leave a comment on either the commit or PR with relevant test results. Requires proper permissions (see [Permissions](#permissions) section below).                                                                                                                             |
 | github-token       |              | `${{ github.token }}` | This token is used for leaving the comments on PRs/commits. By default, we'll use the GitHub actions bot token, but you can override this a repository scoped [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).          |
 | async              |              | false                 | If set, will launch the tests but not wait for them to finish and the action will always output success. Note: Github comments will not function if this is set                                                                                                                                    |
 
@@ -58,7 +59,9 @@ jobs:
           project-id: YOUR_PROJECT_ID
           # Optional: specify Playwright project(s) to run (instead of all projects)
           playwright-project-name: smoke-tests
-          # Optional: override environment variables
+          # Optional: select which environment to load variables from
+          environment-name: Staging
+          # Optional: override specific environment variables
           env-overrides: |
             BASE_URL: https://staging.example.com
             API_KEY: abc123

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,11 @@ inputs:
       Example:
         BASE_URL: https://staging.example.com
         API_KEY: abc123
+  environment-name:
+    description: |-
+      Name of the environment to use for this run (v2 only).
+      For example: "Staging", "Production".
+      When omitted, falls back to the project's default environment.
   test-group-id:
     description: The test group ID to execute (v1 only)
     deprecationMessage:
@@ -65,7 +70,8 @@ inputs:
     default: 'false'
   environment:
     description: |-
-      The environment to inherit variables from (v1 only, v2 support soon).
+      The environment to inherit variables from (v1 only).
+      For v2, use environment-name instead.
       Defaults to 'PRODUCTION'.
     default: 'PRODUCTION'
   variable-overrides:

--- a/dist/index.js
+++ b/dist/index.js
@@ -36082,6 +36082,7 @@ function parseInput() {
     const envOverrides = envOverridesJson
         ? parseObjectInput('env-overrides', envOverridesJson)
         : undefined;
+    const environmentName = (0, core_1.getInput)('environment-name').trim() || undefined;
     // V1 inputs (supporting deprecating of runGroupIds)
     const testSuiteIdInput = (0, core_1.getInput)('test-suite-id');
     const testGroupIdInput = (0, core_1.getInput)('test-group-id');
@@ -36131,7 +36132,8 @@ function parseInput() {
                 version: 'v2',
                 projectId,
                 playwrightProjectName: playwrightProjectName || undefined,
-                envOverrides
+                envOverrides,
+                environmentName
             }
             : {
                 version: 'v1',
@@ -36250,13 +36252,14 @@ async function runV1({ apiKey, urlReplacement, githubComment, githubToken, testS
         (0, core_1.setFailed)(e instanceof Error ? e.message : `An unknown error occurred`);
     }
 }
-async function runV2({ apiKey, projectId, playwrightProjectName, githubComment, githubToken, runInAsyncMode, envOverrides }) {
+async function runV2({ apiKey, projectId, playwrightProjectName, githubComment, githubToken, runInAsyncMode, envOverrides, environmentName }) {
     const { runId } = await (0, playwright_api_1.startPlaywrightRun)({
         projectId,
         apiKey,
         options: {
             playwrightProjectName,
-            envOverrides
+            envOverrides,
+            environmentName
         }
     });
     (0, core_1.setOutput)('testSuiteRunId', runId);
@@ -36402,7 +36405,8 @@ async function startPlaywrightRun({ projectId, apiKey, options }) {
     ]);
     const body = {
         playwrightProjectName: options.playwrightProjectName,
-        envOverrides: options.envOverrides
+        envOverrides: options.envOverrides,
+        environmentName: options.environmentName
     };
     const runUrl = new URL(`/v1/projects/${projectId}/runs`, API_ENDPOINT).href;
     const runResponse = await httpClient.postJson(runUrl, body, {

--- a/src/input.ts
+++ b/src/input.ts
@@ -24,6 +24,7 @@ type V2Input = BaseInput & {
   projectId: string;
   playwrightProjectName: string | undefined;
   envOverrides: Record<string, string> | undefined;
+  environmentName: string | undefined;
 };
 
 type V1Input = BaseInput & {
@@ -61,6 +62,7 @@ export function parseInput(): ParsedInput {
         string
       >)
     : undefined;
+  const environmentName = getInput('environment-name').trim() || undefined;
 
   // V1 inputs (supporting deprecating of runGroupIds)
   const testSuiteIdInput = getInput('test-suite-id');
@@ -137,7 +139,8 @@ export function parseInput(): ParsedInput {
           version: 'v2' as const,
           projectId,
           playwrightProjectName: playwrightProjectName || undefined,
-          envOverrides
+          envOverrides,
+          environmentName
         }
       : {
           version: 'v1' as const,

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,14 +118,16 @@ async function runV2({
   githubComment,
   githubToken,
   runInAsyncMode,
-  envOverrides
+  envOverrides,
+  environmentName
 }: V2Input): Promise<void> {
   const { runId } = await startPlaywrightRun({
     projectId,
     apiKey,
     options: {
       playwrightProjectName,
-      envOverrides
+      envOverrides,
+      environmentName
     }
   });
   setOutput('testSuiteRunId', runId);

--- a/src/stably/api/playwright-api.ts
+++ b/src/stably/api/playwright-api.ts
@@ -69,6 +69,7 @@ export async function startPlaywrightRun({
   options: {
     playwrightProjectName?: string;
     envOverrides?: Record<string, string>;
+    environmentName?: string;
   };
 }): Promise<PlaywrightRunResponse> {
   const httpClient = new HttpClient('github-action', [
@@ -77,7 +78,8 @@ export async function startPlaywrightRun({
 
   const body = {
     playwrightProjectName: options.playwrightProjectName,
-    envOverrides: options.envOverrides
+    envOverrides: options.envOverrides,
+    environmentName: options.environmentName
   };
 
   const runUrl = new URL(`/v1/projects/${projectId}/runs`, API_ENDPOINT).href;


### PR DESCRIPTION
## Summary
- Adds `environment-name` input for v2 (Playwright) runs, allowing users to select a named environment (e.g. "Staging", "Production") from the GitHub Action
- The name is passed as `environmentName` in the API request body, which the server resolves to load the corresponding environment variables
- `env-overrides` still take precedence over environment variables from the selected environment
- Updates README with the new input in the v2 inputs table and example workflow

## Test plan
- [ ] Run the action with `environment-name: Staging` and verify the correct environment variables are loaded
- [ ] Run the action without `environment-name` and verify it falls back to the project's default environment
- [ ] Run with both `environment-name` and `env-overrides` and verify overrides take precedence
- [ ] Run with an invalid environment name and verify a clear error is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)